### PR TITLE
Add missing GL header import to fix build on 10.9

### DIFF
--- a/Source/VideoLayer.h
+++ b/Source/VideoLayer.h
@@ -6,6 +6,7 @@
 //
 
 #import <Cocoa/Cocoa.h>
+#import <OpenGL/gl.h>
 
 @interface VideoLayer : CAOpenGLLayer
 


### PR DESCRIPTION
It seems that an explicit import is required for <OpenGL/gl.h> is required when building on 10.9, to find definitions for the gl_ functions.
