### PR TITLE
OS 10.9 Compatibility

### DIFF
--- a/Source/VideoLayer.m
+++ b/Source/VideoLayer.m
@@ -6,6 +6,7 @@
 //
 
 #import "VideoLayer.h"
+#import <OpenGL/gl.h>
 
 @implementation VideoLayer {
     CVOpenGLTextureCacheRef _textureCache;


### PR DESCRIPTION
The only thing required was to explicitly import gl headers
Have no 10.8 or earlier to test if it keeps building well there.
