### PR TITLE
Update in README.md, typo in installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Or, you can install the bleeding-edge version of `mplayer` this way:
 
     brew remove ffmpeg
     brew remove mplayer
-    brew install --HEAD ffmeg
+    brew install --HEAD ffmpeg
     brew install --HEAD mplayer
 
 For `mplayer2`, installation instructions via Homebrew are available [here](https://github.com/pigoz/homebrew-mplayer2).


### PR DESCRIPTION
Just a typo in the brew installation command for the installation of the bleeding-edge version of mplayer

Not a big thing, but when copy/paste command, nice to remove the typo

Thanks,

Pierre
